### PR TITLE
Fix run.rb to avoid constant collisions

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -1,6 +1,6 @@
 #write block of code to loop through and for each one. 
 
-require 'benchmark'
+require 'open3'
 
 path = File.expand_path(File.dirname(__FILE__))
 
@@ -10,8 +10,10 @@ total_time = 0.0
 Dir.glob("solutions/*.rb").each do |x|
   puts x
   timer_start = Time.now
-  load File.join(path, x)
+  stdout, stderr, status = Open3.capture3('ruby', File.join(path, x))
   timer = ((Time.now - timer_start)) * 1000
+  puts stdout unless stdout.empty?
+  warn stderr unless stderr.empty?
   results << [File.basename(x), timer]
   puts "Time: #{timer} ms"
 


### PR DESCRIPTION
## Summary
- run solutions in separate Ruby processes instead of using `load`
- print captured stdout/stderr for each solution

## Testing
- `ruby -c run.rb`

------
https://chatgpt.com/codex/tasks/task_e_6849cd3f1d08833190cd7fc8966975ef